### PR TITLE
Separate navigation from header

### DIFF
--- a/dist/script.js
+++ b/dist/script.js
@@ -14,6 +14,18 @@ var modules = [{
   path: 'modules/programming.json',
   name: 'Programmering'
 }];
+function ModuleNav(_ref) {
+  var modules = _ref.modules,
+    onSelect = _ref.onSelect;
+  return /*#__PURE__*/React.createElement("nav", null, modules.map(function (m) {
+    return /*#__PURE__*/React.createElement("button", {
+      key: m.name,
+      onClick: function onClick() {
+        return onSelect(m);
+      }
+    }, m.name);
+  }));
+}
 function App() {
   var _React$useState = React.useState(null),
     _React$useState2 = _slicedToArray(_React$useState, 2),
@@ -27,7 +39,7 @@ function App() {
     document.body.className = darkMode ? 'dark' : 'light';
   }, [darkMode]);
   var loadModule = /*#__PURE__*/function () {
-    var _ref = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee(mod) {
+    var _ref2 = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee(mod) {
       var res, data;
       return _regenerator().w(function (_context) {
         while (1) switch (_context.n) {
@@ -47,19 +59,12 @@ function App() {
       }, _callee);
     }));
     return function loadModule(_x) {
-      return _ref.apply(this, arguments);
+      return _ref2.apply(this, arguments);
     };
   }();
   return /*#__PURE__*/React.createElement("div", {
     className: "app"
-  }, /*#__PURE__*/React.createElement("header", null, /*#__PURE__*/React.createElement("h1", null, "L\xE4rplattform"), /*#__PURE__*/React.createElement("nav", null, modules.map(function (m) {
-    return /*#__PURE__*/React.createElement("button", {
-      key: m.name,
-      onClick: function onClick() {
-        return loadModule(m);
-      }
-    }, m.name);
-  })), /*#__PURE__*/React.createElement("div", {
+  }, /*#__PURE__*/React.createElement("header", null, /*#__PURE__*/React.createElement("h1", null, "L\xE4rplattform"), /*#__PURE__*/React.createElement("div", {
     className: "mode-switch"
   }, /*#__PURE__*/React.createElement("label", null, /*#__PURE__*/React.createElement("input", {
     type: "checkbox",
@@ -67,7 +72,10 @@ function App() {
     onChange: function onChange() {
       return setDarkMode(!darkMode);
     }
-  }), darkMode ? 'Dark' : 'Light'))), /*#__PURE__*/React.createElement("main", null, currentModule ? currentModule.lessons.map(function (lesson, idx) {
+  }), darkMode ? 'Dark' : 'Light'))), /*#__PURE__*/React.createElement(ModuleNav, {
+    modules: modules,
+    onSelect: loadModule
+  }), /*#__PURE__*/React.createElement("main", null, currentModule ? currentModule.lessons.map(function (lesson, idx) {
     return /*#__PURE__*/React.createElement("div", {
       key: idx,
       className: "lesson"

--- a/script.js
+++ b/script.js
@@ -2,6 +2,18 @@ const modules = [
   { path: 'modules/programming.json', name: 'Programmering' }
 ];
 
+function ModuleNav({ modules, onSelect }) {
+  return (
+    <nav>
+      {modules.map((m) => (
+        <button key={m.name} onClick={() => onSelect(m)}>
+          {m.name}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
 function App() {
   const [currentModule, setCurrentModule] = React.useState(null);
   const [darkMode, setDarkMode] = React.useState(false);
@@ -20,11 +32,6 @@ function App() {
     <div className="app">
       <header>
         <h1>Lärplattform</h1>
-        <nav>
-          {modules.map((m) => (
-            <button key={m.name} onClick={() => loadModule(m)}>{m.name}</button>
-          ))}
-        </nav>
         <div className="mode-switch">
           <label>
             <input
@@ -36,6 +43,7 @@ function App() {
           </label>
         </div>
       </header>
+      <ModuleNav modules={modules} onSelect={loadModule} />
       <main>
         {currentModule ? (
           currentModule.lessons.map((lesson, idx) => (

--- a/style.css
+++ b/style.css
@@ -38,6 +38,7 @@ header {
 nav {
   display: flex;
   gap: 0.5rem;
+  margin-top: 1rem;
 }
 
 nav button {


### PR DESCRIPTION
## Summary
- extract module navigation to new `ModuleNav` component
- move navigation outside header and leave header with title and mode switch
- add top margin for `nav` styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a352a009c8333a363e01a704b75a1