### PR TITLE
feat: add theme accent options

### DIFF
--- a/dist/script.js
+++ b/dist/script.js
@@ -23,9 +23,13 @@ function App() {
     _React$useState4 = _slicedToArray(_React$useState3, 2),
     darkMode = _React$useState4[0],
     setDarkMode = _React$useState4[1];
+  var _React$useState5 = React.useState('primary'),
+    _React$useState6 = _slicedToArray(_React$useState5, 2),
+    accent = _React$useState6[0],
+    setAccent = _React$useState6[1];
   React.useEffect(function () {
-    document.body.className = darkMode ? 'dark' : 'light';
-  }, [darkMode]);
+    document.body.className = "".concat(darkMode ? 'dark' : 'light', " accent-").concat(accent);
+  }, [darkMode, accent]);
   var loadModule = /*#__PURE__*/function () {
     var _ref = _asyncToGenerator(/*#__PURE__*/_regenerator().m(function _callee(mod) {
       var res, data;
@@ -67,7 +71,16 @@ function App() {
     onChange: function onChange() {
       return setDarkMode(!darkMode);
     }
-  }), darkMode ? 'Dark' : 'Light'))), /*#__PURE__*/React.createElement("main", null, currentModule ? currentModule.lessons.map(function (lesson, idx) {
+  }), darkMode ? 'Dark' : 'Light'), /*#__PURE__*/React.createElement("select", {
+    value: accent,
+    onChange: function onChange(e) {
+      return setAccent(e.target.value);
+    }
+  }, /*#__PURE__*/React.createElement("option", {
+    value: "primary"
+  }, "Primary"), /*#__PURE__*/React.createElement("option", {
+    value: "neutral"
+  }, "Neutral")))), /*#__PURE__*/React.createElement("main", null, currentModule ? currentModule.lessons.map(function (lesson, idx) {
     return /*#__PURE__*/React.createElement("div", {
       key: idx,
       className: "lesson"

--- a/script.js
+++ b/script.js
@@ -5,10 +5,11 @@ const modules = [
 function App() {
   const [currentModule, setCurrentModule] = React.useState(null);
   const [darkMode, setDarkMode] = React.useState(false);
+  const [accent, setAccent] = React.useState('primary');
 
   React.useEffect(() => {
-    document.body.className = darkMode ? 'dark' : 'light';
-  }, [darkMode]);
+    document.body.className = `${darkMode ? 'dark' : 'light'} accent-${accent}`;
+  }, [darkMode, accent]);
 
   const loadModule = async (mod) => {
     const res = await fetch(mod.path);
@@ -34,6 +35,10 @@ function App() {
             />
             {darkMode ? 'Dark' : 'Light'}
           </label>
+          <select value={accent} onChange={(e) => setAccent(e.target.value)}>
+            <option value="primary">Primary</option>
+            <option value="neutral">Neutral</option>
+          </select>
         </div>
       </header>
       <main>

--- a/style.css
+++ b/style.css
@@ -12,7 +12,8 @@ body {
 body.light {
   --bg: #fdfdfd;
   --text: #222;
-  --accent: #1976d2;
+  --accent-primary: #1976d2;
+  --accent-neutral: #9e9e9e;
   --card: #ffffff;
   --exercise-bg: #e3f2fd;
 }
@@ -20,13 +21,18 @@ body.light {
 body.dark {
   --bg: #121212;
   --text: #e0e0e0;
-  --accent: #90caf9;
+  --accent-primary: #90caf9;
+  --accent-neutral: #b0bec5;
   --card: #1e1e1e;
   --exercise-bg: #1a237e;
 }
 
+body.accent-neutral {
+  --accent-primary: var(--accent-neutral);
+}
+
 header {
-  background: var(--accent);
+  background: var(--accent-primary);
   color: white;
   padding: 1rem;
   display: flex;
@@ -42,7 +48,7 @@ nav {
 
 nav button {
   background: white;
-  color: var(--accent);
+  color: var(--accent-primary);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;
@@ -74,6 +80,6 @@ main {
 .exercise {
   background: var(--exercise-bg);
   padding: 0.5rem 1rem;
-  border-left: 4px solid var(--accent);
+  border-left: 4px solid var(--accent-primary);
   margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- add primary and neutral accent color variables for light and dark themes
- allow switching accent color via new dropdown
- compile updated scripts

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a29d50d548333bb617d151db3c1d3